### PR TITLE
Remove dependendy on Linux kernel headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,10 @@
 DEST_DIR=out
-LINUX_HEADERS="/usr/lib/modules/$(shell uname -r)/build"
 
 build:
 	mkdir -p out
 	clang -D__KERNEL__ -D__ASM_SYSREG_H \
 	-Wno-unused-value -Wno-pointer-sign -Wno-compare-distinct-pointer-types \
+			-fno-stack-protector \
 			-O2 -emit-llvm -c bpf/cgroup-tracer-bpf.c \
-			$(foreach path,$(LINUX_HEADERS), -I $(path)/arch/x86/include -I $(path)/arch/x86/include/generated -I $(path)/include -I $(path)/include/generated/uapi -I $(path)/arch/x86/include/uapi -I $(path)/include/uapi) \
 			-o - | llc -march=bpf -filetype=obj -o "${DEST_DIR}/ebpf.o"
 	go build

--- a/bpf/cgroup-tracer-bpf.c
+++ b/bpf/cgroup-tracer-bpf.c
@@ -12,11 +12,11 @@
  * limitations under the License.
  */
 
-#include <linux/kconfig.h>
+#include <stddef.h>
+#include <stdlib.h>
 #include <linux/bpf.h>
-#include <uapi/linux/tcp.h>
-#include <uapi/linux/if_ether.h>
-#include <uapi/linux/ip.h>
+#include <linux/ip.h>
+#include <linux/tcp.h>
 #include "bpf_helpers.h"
 
 struct bpf_map_def SEC("maps/count") count_map = {
@@ -30,8 +30,8 @@ SEC("cgroup/skb")
 int count_packets(struct __sk_buff *skb)
 {
 	int packets_key = 0, bytes_key = 1;
-	u64 *packets = NULL;
-	u64 *bytes = NULL;
+	__u64 *packets = NULL;
+	__u64 *bytes = NULL;
 
 	packets = bpf_map_lookup_elem(&count_map, &packets_key);
 	if (packets == NULL)
@@ -43,10 +43,10 @@ int count_packets(struct __sk_buff *skb)
 	if (bytes == NULL)
 		return 0;
 
-	u16 dest = 0;
+	__u16 dest = 0;
 	bpf_skb_load_bytes(skb, sizeof(struct iphdr) + offsetof(struct tcphdr, dest), &dest, sizeof(dest));
 
-	if (dest == ntohs(80))
+	if (dest == __constant_ntohs(80))
 		*bytes += skb->len;
 
 	// don't drop


### PR DESCRIPTION
`cgroup-tracer-bpf` should not require kernel source to be available and using headers from `/usr/include` should be enough.
With having the dependency, build will succeed only when the kernel source tree is properly configured, which is not always the case.

See also https://github.com/kinvolk/cgnet/pull/17